### PR TITLE
feat: add light network hero and infographic

### DIFF
--- a/BlackridgePortfolio/index.html
+++ b/BlackridgePortfolio/index.html
@@ -59,7 +59,9 @@
         }
         
         .hero-bg {
-            background: linear-gradient(135deg, #F8FAFC 0%, #E2E8F0 100%);
+            background: radial-gradient(circle at 30% 30%, rgba(14, 165, 233, 0.2) 0%, rgba(14, 165, 233, 0.05) 40%, transparent 70%),
+                        radial-gradient(circle at 70% 70%, rgba(14, 165, 233, 0.15) 0%, transparent 60%),
+                        #f0f9ff;
             position: relative;
             overflow: hidden;
         }
@@ -78,10 +80,22 @@
         }
         
         .card-enterprise {
-            background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(10px);
-            border: 1px solid rgba(255, 255, 255, 0.2);
-            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
+            background: rgba(255, 255, 255, 0.9);
+            backdrop-filter: blur(16px);
+            border: 1px solid rgba(14, 165, 233, 0.15);
+            box-shadow: 0 20px 40px rgba(14, 165, 233, 0.1);
+            color: #1f2937;
+        }
+
+        .card-enterprise h2,
+        .card-enterprise h3,
+        .card-enterprise h4 {
+            color: #1f2937;
+        }
+
+        .card-enterprise .text-secondary,
+        .card-enterprise .text-light-gray {
+            color: #64748b;
         }
         
         .btn-primary {
@@ -90,6 +104,7 @@
             border: none;
             position: relative;
             overflow: hidden;
+            box-shadow: 0 0 20px rgba(14, 165, 233, 0.4);
         }
         
         .btn-primary::before {
@@ -109,7 +124,7 @@
         
         .btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 10px 25px rgba(14, 165, 233, 0.4);
+            box-shadow: 0 0 30px rgba(14, 165, 233, 0.6);
         }
         
         .btn-secondary {
@@ -117,13 +132,14 @@
             color: #0EA5E9;
             border: 2px solid #0EA5E9;
             transition: all 0.3s ease;
+            box-shadow: 0 0 10px rgba(14, 165, 233, 0.2);
         }
         
         .btn-secondary:hover {
             background: #0EA5E9;
             color: white;
             transform: translateY(-2px);
-            box-shadow: 0 8px 20px rgba(14, 165, 233, 0.3);
+            box-shadow: 0 0 20px rgba(14, 165, 233, 0.4);
         }
         
         .icon-primary {
@@ -294,6 +310,7 @@
     
     <!-- Hero Section -->
     <section class="hero-bg section-enterprise pt-24 pb-16 lg:pb-24">
+        <canvas id="network-canvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
         <div class="container mx-auto max-w-7xl relative z-10">
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center min-h-[80vh]">
                 <!-- Hero Content -->
@@ -302,7 +319,7 @@
                         <span class="block lg:inline">Transforming Digital</span>
                         <span class="block lg:inline text-gradient">Infrastructure</span>
                     </h1>
-                    <p class="text-sm md:text-base lg:text-lg text-light-gray mb-8 max-w-2xl mx-auto lg:mx-0 leading-relaxed">
+                    <p class="text-sm md:text-base lg:text-lg text-secondary mb-8 max-w-2xl mx-auto lg:mx-0 leading-relaxed">
                         We build ethical, scalable platforms that empower freelancers, creators, and digital entrepreneurs to thrive in the modern economy.
                     </p>
                     <div class="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
@@ -634,19 +651,53 @@
         </div>
     </section>
 
+    <!-- Infographic Section -->
+    <section id="infographic" class="section-enterprise bg-bg-light">
+        <div class="container mx-auto max-w-6xl">
+            <div class="text-center mb-12">
+                <h2 class="text-2xl md:text-3xl lg:text-4xl font-bold text-dark-gray mb-6" data-aos="fade-up">
+                    Our Platform at a Glance
+                </h2>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8" data-aos="fade-up" data-aos-delay="200">
+                <div class="flex flex-col items-center">
+                    <svg class="w-24 h-24 text-primary mb-4" viewBox="0 0 100 100">
+                        <circle cx="50" cy="50" r="45" stroke="currentColor" stroke-width="10" fill="none"/>
+                        <line x1="50" y1="15" x2="50" y2="50" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+                    </svg>
+                    <p class="text-dark-gray font-bold text-lg">1M+ Users</p>
+                </div>
+                <div class="flex flex-col items-center">
+                    <svg class="w-24 h-24 text-primary mb-4" viewBox="0 0 100 100">
+                        <rect x="15" y="15" width="70" height="70" stroke="currentColor" stroke-width="10" fill="none"/>
+                        <path d="M15 70 L50 40 L85 70" stroke="currentColor" stroke-width="10" fill="none"/>
+                    </svg>
+                    <p class="text-dark-gray font-bold text-lg">500K Freelancers</p>
+                </div>
+                <div class="flex flex-col items-center">
+                    <svg class="w-24 h-24 text-primary mb-4" viewBox="0 0 100 100">
+                        <polygon points="50,15 90,85 10,85" stroke="currentColor" stroke-width="10" fill="none"/>
+                        <circle cx="50" cy="55" r="15" stroke="currentColor" stroke-width="10" fill="none"/>
+                    </svg>
+                    <p class="text-dark-gray font-bold text-lg">99% Uptime</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Contact & Footer Section -->
-    <footer id="contact" class="section-enterprise bg-slate-900 text-white">
+    <footer id="contact" class="section-enterprise bg-bg-light text-dark-gray">
         <div class="container mx-auto max-w-6xl">
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-12 mb-12">
                 <!-- Company Info -->
                 <div data-aos="fade-up">
-                    <img src="assets/blackridge-logo.png" alt="Blackridge Group Ltd" class="h-10 w-auto mb-6 filter brightness-0 invert">
-                    <p class="text-slate-300 leading-relaxed mb-6">
+                    <img src="assets/blackridge-logo.png" alt="Blackridge Group Ltd" class="h-10 w-auto mb-6">
+                    <p class="text-secondary leading-relaxed mb-6">
                         Transforming digital infrastructure through ethical, scalable platforms that empower global communities.
                     </p>
                     <div class="space-y-2">
-                        <p class="text-sm text-slate-400">Registered Address:</p>
-                        <p class="text-slate-300">
+                        <p class="text-sm text-light-gray">Registered Address:</p>
+                        <p class="text-secondary">
                             61 Bridge Street<br>
                             Kington<br>
                             Hertfordshire<br>
@@ -660,12 +711,12 @@
                 <div data-aos="fade-up" data-aos-delay="200">
                     <h3 class="text-xl font-bold mb-6">Quick Links</h3>
                     <nav class="space-y-3">
-                        <a href="#about" class="block text-slate-300 hover:text-white transition-colors">About Us</a>
-                        <a href="#values" class="block text-slate-300 hover:text-white transition-colors">Our Values</a>
-                        <a href="#vision" class="block text-slate-300 hover:text-white transition-colors">Vision & Mission</a>
-                        <a href="https://orbas.io" target="_blank" rel="noopener noreferrer" class="block text-slate-300 hover:text-white transition-colors">Orbas Platform</a>
-                        <a href="privacy.html" class="block text-slate-300 hover:text-white transition-colors">Privacy Policy</a>
-                        <a href="#" class="block text-slate-300 hover:text-white transition-colors">Terms of Service</a>
+                        <a href="#about" class="block text-secondary hover:text-primary transition-colors">About Us</a>
+                        <a href="#values" class="block text-secondary hover:text-primary transition-colors">Our Values</a>
+                        <a href="#vision" class="block text-secondary hover:text-primary transition-colors">Vision & Mission</a>
+                        <a href="https://orbas.io" target="_blank" rel="noopener noreferrer" class="block text-secondary hover:text-primary transition-colors">Orbas Platform</a>
+                        <a href="privacy.html" class="block text-secondary hover:text-primary transition-colors">Privacy Policy</a>
+                        <a href="#" class="block text-secondary hover:text-primary transition-colors">Terms of Service</a>
                     </nav>
                 </div>
                 
@@ -677,7 +728,7 @@
                             <svg class="w-5 h-5 text-primary-light" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
                             </svg>
-                            <a href="mailto:info@blackridgegroup.online" class="text-slate-300 hover:text-white transition-colors">
+                            <a href="mailto:info@blackridgegroup.online" class="text-secondary hover:text-primary transition-colors">
                                 info@blackridgegroup.online
                             </a>
                         </div>
@@ -685,19 +736,19 @@
                             <svg class="w-5 h-5 text-primary-light" fill="currentColor" viewBox="0 0 24 24">
                                 <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
                             </svg>
-                            <a href="https://www.linkedin.com/company/blackridge-group-ltd/" target="_blank" rel="noopener noreferrer" class="text-slate-300 hover:text-white transition-colors">LinkedIn</a>
+                            <a href="https://www.linkedin.com/company/blackridge-group-ltd/" target="_blank" rel="noopener noreferrer" class="text-secondary hover:text-primary transition-colors">LinkedIn</a>
                         </div>
                     </div>
                 </div>
             </div>
             
             <!-- Bottom Bar -->
-            <div class="border-t border-slate-700 pt-8 text-center" data-aos="fade-up" data-aos-delay="600">
-                <p class="text-slate-400 text-sm">
+            <div class="border-t border-border-gray pt-8 text-center" data-aos="fade-up" data-aos-delay="600">
+                <p class="text-light-gray text-sm">
                     © 2025 Blackridge Group Ltd. All rights reserved. | Company Registration: 16482166
                 </p>
-                <p class="text-slate-500 text-xs mt-2">
-                    This website uses cookies to enhance user experience. By continuing to browse, you agree to our <a href="privacy.html#cookies" class="underline hover:text-white">Privacy Policy</a>.
+                <p class="text-light-gray text-xs mt-2">
+                    This website uses cookies to enhance user experience. By continuing to browse, you agree to our <a href="privacy.html#cookies" class="underline hover:text-primary">Privacy Policy</a>.
                 </p>
             </div>
         </div>
@@ -788,6 +839,63 @@
         document.querySelectorAll('section').forEach(section => {
             observer.observe(section);
         });
+
+        // Animated network background
+        const networkCanvas = document.getElementById('network-canvas');
+        if (networkCanvas) {
+            const ctx = networkCanvas.getContext('2d');
+            const NODE_COUNT = 40;
+            const nodes = [];
+
+            function resizeCanvas() {
+                networkCanvas.width = networkCanvas.offsetWidth;
+                networkCanvas.height = networkCanvas.offsetHeight;
+            }
+
+            window.addEventListener('resize', resizeCanvas);
+            resizeCanvas();
+
+            for (let i = 0; i < NODE_COUNT; i++) {
+                nodes.push({
+                    x: Math.random() * networkCanvas.width,
+                    y: Math.random() * networkCanvas.height,
+                    vx: (Math.random() - 0.5) * 0.5,
+                    vy: (Math.random() - 0.5) * 0.5
+                });
+            }
+
+            function drawNetwork() {
+                ctx.clearRect(0, 0, networkCanvas.width, networkCanvas.height);
+                nodes.forEach((node, i) => {
+                    node.x += node.vx;
+                    node.y += node.vy;
+
+                    if (node.x < 0 || node.x > networkCanvas.width) node.vx *= -1;
+                    if (node.y < 0 || node.y > networkCanvas.height) node.vy *= -1;
+
+                    ctx.beginPath();
+                    ctx.arc(node.x, node.y, 2, 0, Math.PI * 2);
+                    ctx.fillStyle = 'rgba(14,165,233,0.8)';
+                    ctx.fill();
+
+                    for (let j = i + 1; j < NODE_COUNT; j++) {
+                        const other = nodes[j];
+                        const dist = Math.hypot(node.x - other.x, node.y - other.y);
+                        if (dist < 100) {
+                            ctx.strokeStyle = `rgba(14,165,233,${1 - dist / 100})`;
+                            ctx.lineWidth = 0.5;
+                            ctx.beginPath();
+                            ctx.moveTo(node.x, node.y);
+                            ctx.lineTo(other.x, other.y);
+                            ctx.stroke();
+                        }
+                    }
+                });
+                requestAnimationFrame(drawNetwork);
+            }
+
+            drawNetwork();
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- lighten hero and footer with soft blue scheme
- overlay animated canvas network in hero
- include SVG-based infographic of platform stats

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b125d51780832088cbfeb69d0bd4e8