### PR TITLE
Refresh brand palette and remove placeholder badge

### DIFF
--- a/BlackridgePortfolio/index.html
+++ b/BlackridgePortfolio/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blackwellen Ltd &mdash; Tech-Focused Investment Holdings Company</title>
     <meta name="description" content="Blackwellen Ltd is a technology-focused investment company building and backing high-potential brands, digital platforms, and emerging technologies.">
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://i.ibb.co/s912pw8N/craiyon-013816-image.png">
+    <link rel="shortcut icon" href="https://i.ibb.co/s912pw8N/craiyon-013816-image.png">
 
     <!-- Google Fonts - Poppins -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -37,8 +37,8 @@
                         'soft-gray': '#9CA3AF',
                         'cool-gray': '#6B7280',
                         'divider': 'rgba(255,255,255,0.08)',
-                        'gilded': '#3B82F6',
-                        'gilded-soft': '#BAE6FD'
+                        'gilded': '#0A8ED4',
+                        'gilded-soft': '#AEEFFF'
                     }
                 }
             }
@@ -49,9 +49,9 @@
         :root {
             --crestgate-black: #050507;
             --hero-image-black: #06080B;
-            --crestgate-accent-base: #3b82f6;
-            --crestgate-accent-highlight: #93c5fd;
-            --crestgate-accent-shadow: #0b1f4b;
+            --crestgate-accent-base: #0a8ed4;
+            --crestgate-accent-highlight: #7fd3ff;
+            --crestgate-accent-shadow: #053b59;
             --hero-visual-aspect: 1600 / 1100;
         }
 
@@ -79,8 +79,8 @@
             position: absolute;
             inset: 0;
             pointer-events: none;
-            background: radial-gradient(circle at 12% 8%, rgba(37, 99, 235, 0.08), transparent 42%),
-                        radial-gradient(circle at 88% 12%, rgba(96, 165, 250, 0.05), transparent 48%);
+            background: radial-gradient(circle at 12% 8%, rgba(10, 142, 212, 0.08), transparent 42%),
+                        radial-gradient(circle at 88% 12%, rgba(127, 211, 255, 0.05), transparent 48%);
             opacity: 0.5;
         }
 
@@ -96,13 +96,13 @@
 
         .glass-card {
             background: rgba(17, 17, 24, 0.72);
-            border: 1px solid rgba(59, 130, 246, 0.1);
+            border: 1px solid rgba(10, 142, 212, 0.18);
             box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
             backdrop-filter: blur(18px);
         }
 
         .glass-card:hover {
-            border-color: rgba(59, 130, 246, 0.24);
+            border-color: rgba(10, 142, 212, 0.32);
         }
 
         .scaffold-block,
@@ -110,7 +110,7 @@
         .scaffold-strip {
             position: relative;
             border-radius: 28px;
-            border: 1px dashed rgba(147, 197, 253, 0.35);
+            border: 1px dashed rgba(163, 230, 255, 0.35);
             min-height: 180px;
             display: flex;
             align-items: center;
@@ -141,7 +141,7 @@
         .scaffold-ribbon {
             position: absolute;
             inset: 0;
-            background: linear-gradient(120deg, rgba(96, 165, 250, 0.08), rgba(5, 5, 7, 0) 48%);
+            background: linear-gradient(120deg, rgba(127, 211, 255, 0.08), rgba(5, 5, 7, 0) 48%);
             mix-blend-mode: screen;
         }
 
@@ -149,7 +149,7 @@
             text-transform: uppercase;
             letter-spacing: 0.35em;
             font-size: 0.7rem;
-            color: rgba(147, 197, 253, 0.85);
+            color: rgba(163, 230, 255, 0.85);
         }
 
         .scaffold-block::after,
@@ -158,7 +158,7 @@
             content: '';
             position: absolute;
             inset: 0;
-            background: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.12), transparent 60%);
+            background: radial-gradient(circle at 20% 20%, rgba(127, 211, 255, 0.12), transparent 60%);
             opacity: 0.65;
             pointer-events: none;
         }
@@ -191,7 +191,7 @@
         .hero-metric {
             border-radius: 1.5rem;
             background: rgba(8, 8, 12, 0.9);
-            border: 1px solid rgba(147, 197, 253, 0.16);
+            border: 1px solid rgba(163, 230, 255, 0.16);
             padding: 1.5rem;
         }
 
@@ -201,7 +201,7 @@
             text-transform: uppercase;
             font-size: 0.55rem;
             margin-bottom: 0.65rem;
-            color: rgba(147, 197, 253, 0.8);
+            color: rgba(163, 230, 255, 0.8);
         }
 
         .hero-metric strong {
@@ -222,7 +222,7 @@
             width: 160px;
             height: 160px;
             transform: translate(-50%, -50%);
-            background: radial-gradient(circle, rgba(255, 255, 255, 0.6) 0%, rgba(147, 197, 253, 0.35) 28%, rgba(147, 197, 253, 0) 70%);
+            background: radial-gradient(circle, rgba(255, 255, 255, 0.6) 0%, rgba(163, 230, 255, 0.35) 28%, rgba(163, 230, 255, 0) 70%);
             opacity: 0;
             transition: opacity 0.35s ease;
             pointer-events: none;
@@ -260,8 +260,8 @@
             aspect-ratio: 1 / 1;
             transform: translate(-50%, -50%);
             border-radius: 50%;
-            background: radial-gradient(circle at 30% 30%, rgba(224, 242, 254, 0.95), rgba(37, 99, 235, 0.85) 55%, rgba(11, 31, 75, 0.75) 75%, rgba(5, 5, 7, 0.92));
-            box-shadow: inset 0 1px 8px rgba(255, 255, 255, 0.45), 0 35px 85px rgba(37, 99, 235, 0.35);
+            background: radial-gradient(circle at 30% 30%, rgba(224, 248, 255, 0.95), rgba(10, 142, 212, 0.85) 55%, rgba(5, 59, 90, 0.75) 75%, rgba(5, 5, 7, 0.92));
+            box-shadow: inset 0 1px 8px rgba(255, 255, 255, 0.45), 0 35px 85px rgba(10, 142, 212, 0.35);
             animation: orbPulse 12s ease-in-out infinite;
         }
 
@@ -271,7 +271,7 @@
             position: absolute;
             inset: -35%;
             border-radius: 50%;
-            border: 1px solid rgba(96, 165, 250, 0.22);
+            border: 1px solid rgba(127, 211, 255, 0.22);
             filter: blur(0.6px);
             animation: orbRing 18s linear infinite;
         }
@@ -280,7 +280,7 @@
             inset: -55%;
             animation-duration: 26s;
             animation-direction: reverse;
-            border-color: rgba(147, 197, 253, 0.12);
+            border-color: rgba(163, 230, 255, 0.12);
         }
 
         .orb-glare {
@@ -300,18 +300,18 @@
             position: absolute;
             inset: 12% 8%;
             border-radius: 50%;
-            border: 1px solid rgba(147, 197, 253, 0.08);
+            border: 1px solid rgba(163, 230, 255, 0.08);
             filter: blur(0.4px);
         }
 
         .orb-rail:nth-of-type(2) {
             inset: 22% 14%;
-            border-color: rgba(147, 197, 253, 0.14);
+            border-color: rgba(163, 230, 255, 0.14);
         }
 
         .orb-rail:nth-of-type(3) {
             inset: 33% 22%;
-            border-color: rgba(147, 197, 253, 0.2);
+            border-color: rgba(163, 230, 255, 0.2);
         }
 
         @keyframes orbPulse {
@@ -371,15 +371,12 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-onyx/85 backdrop-blur-xl border-b border-divider">
         <nav class="container mx-auto max-w-7xl px-4 py-4">
             <div class="flex items-center justify-between">
-                <!-- Logo Placeholder -->
                 <div class="flex items-center space-x-3">
-                    <div class="h-11 w-11 rounded-full border border-gilded/60 bg-gradient-to-br from-gilded/20 via-gilded/5 to-transparent flex items-center justify-center">
-                        <span class="text-gilded text-xl font-semibold">B</span>
-                    </div>
                     <div>
                         <span class="block text-sm tracking-[0.4em] uppercase text-gilded">Blackwellen</span>
                         <span class="block text-lg font-semibold text-white">Ltd</span>
                     </div>
+                    <img src="https://i.ibb.co/tTyXFvBL/craiyon-013431-image.png" alt="Blackwellen Ltd logo" class="h-[7.5rem] w-auto object-contain">
                 </div>
 
                 <!-- Desktop Navigation -->
@@ -714,13 +711,11 @@
                 <!-- Company Info -->
                 <div data-aos="fade-up">
                     <div class="flex items-center space-x-3 mb-6">
-                        <div class="h-11 w-11 rounded-full border border-gilded/60 bg-gradient-to-br from-gilded/20 via-gilded/5 to-transparent flex items-center justify-center">
-                            <span class="text-gilded text-xl font-semibold">B</span>
-                        </div>
                         <div>
                             <span class="block text-sm tracking-[0.4em] uppercase text-gilded">Blackwellen</span>
                             <span class="block text-lg font-semibold text-white">Ltd</span>
                         </div>
+                        <img src="https://i.ibb.co/tTyXFvBL/craiyon-013431-image.png" alt="Blackwellen Ltd logo" class="h-[7.5rem] w-auto object-contain">
                     </div>
                     <p class="text-soft-gray leading-relaxed mb-6">
                         Blackwellen Ltd looks after three future-focused web portals that blend technology, creativity, and practical use.
@@ -1040,9 +1035,9 @@
 
         function applyPremiumStyling() {
             const palette = {
-                base: '#3B82F6',
-                highlight: '#93C5FD',
-                shadow: '#0B1F4B'
+                base: '#0A8ED4',
+                highlight: '#7FD3FF',
+                shadow: '#053B59'
             };
 
             const root = document.documentElement;
@@ -1053,25 +1048,25 @@
             const header = document.querySelector('header');
             if (header) {
                 header.style.background = 'linear-gradient(135deg, rgba(5, 5, 7, 0.95), rgba(10, 10, 14, 0.78))';
-                header.style.borderBottom = '1px solid rgba(96, 165, 250, 0.18)';
+                header.style.borderBottom = '1px solid rgba(127, 211, 255, 0.18)';
                 header.style.boxShadow = '0 25px 65px rgba(0, 0, 0, 0.65)';
             }
 
             const footer = document.querySelector('footer');
             if (footer) {
                 footer.style.background = 'linear-gradient(160deg, rgba(5, 5, 7, 0.95), rgba(14, 12, 8, 0.78))';
-                footer.style.borderTop = '1px solid rgba(96, 165, 250, 0.18)';
+                footer.style.borderTop = '1px solid rgba(127, 211, 255, 0.18)';
                 footer.style.boxShadow = '0 -20px 65px rgba(0, 0, 0, 0.6)';
             }
 
             document.querySelectorAll('.glass-card').forEach(card => {
-                card.style.border = '1px solid rgba(96, 165, 250, 0.18)';
+                card.style.border = '1px solid rgba(127, 211, 255, 0.18)';
                 card.style.boxShadow = '0 45px 95px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.06)';
                 card.style.background = 'linear-gradient(145deg, rgba(17, 17, 24, 0.88), rgba(17, 17, 24, 0.62))';
             });
 
             document.querySelectorAll('.scaffold-block, .scaffold-panel, .scaffold-strip').forEach(scaffold => {
-                scaffold.style.borderColor = 'rgba(96, 165, 250, 0.38)';
+                scaffold.style.borderColor = 'rgba(127, 211, 255, 0.38)';
                 scaffold.style.boxShadow = '0 28px 70px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.06)';
             });
 
@@ -1085,8 +1080,8 @@
                 button.style.background = `linear-gradient(135deg, ${palette.highlight}, ${palette.base} 55%, ${palette.shadow})`;
                 button.style.color = '#050507';
                 button.style.borderRadius = '9999px';
-                button.style.border = '1px solid rgba(186, 230, 253, 0.65)';
-                button.style.boxShadow = '0 25px 60px rgba(37, 99, 235, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.45)';
+                button.style.border = '1px solid rgba(174, 239, 255, 0.65)';
+                button.style.boxShadow = '0 25px 60px rgba(10, 142, 212, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.45)';
                 button.style.transition = 'all 0.45s ease';
                 button.addEventListener('mousemove', event => {
                     const rect = button.getBoundingClientRect();
@@ -1106,13 +1101,13 @@
                     button.appendChild(shine);
                 }
                 const shineEl = button.querySelector('.premium-shine');
-                button.style.border = '1px solid rgba(96, 165, 250, 0.45)';
+                button.style.border = '1px solid rgba(127, 211, 255, 0.45)';
                 button.style.color = palette.highlight;
                 button.style.backdropFilter = 'blur(6px)';
-                button.style.boxShadow = '0 18px 48px rgba(11, 31, 75, 0.35)';
+                button.style.boxShadow = '0 18px 48px rgba(5, 59, 90, 0.35)';
                 button.style.transition = 'all 0.4s ease';
                 button.addEventListener('mouseenter', () => {
-                    button.style.background = 'linear-gradient(135deg, rgba(96, 165, 250, 0.08), rgba(11, 31, 75, 0.25))';
+                    button.style.background = 'linear-gradient(135deg, rgba(127, 211, 255, 0.08), rgba(5, 59, 90, 0.25))';
                 });
                 button.addEventListener('mouseleave', () => {
                     button.style.background = 'transparent';
@@ -1127,7 +1122,7 @@
             });
 
             document.querySelectorAll('.text-gilded').forEach(el => {
-                el.style.textShadow = '0 0 18px rgba(147, 197, 253, 0.45)';
+                el.style.textShadow = '0 0 18px rgba(163, 230, 255, 0.45)';
             });
         }
 
@@ -1143,8 +1138,8 @@
 
             function createBackgroundGradient() {
                 backgroundGradient = ctx.createRadialGradient(width * 0.75, height * 0.35, 0, width * 0.75, height * 0.35, Math.max(width, height));
-                backgroundGradient.addColorStop(0, 'rgba(186, 230, 253, 0.18)');
-                backgroundGradient.addColorStop(0.45, 'rgba(37, 99, 235, 0.15)');
+                backgroundGradient.addColorStop(0, 'rgba(174, 239, 255, 0.18)');
+                backgroundGradient.addColorStop(0.45, 'rgba(10, 142, 212, 0.15)');
                 backgroundGradient.addColorStop(1, 'rgba(5, 5, 7, 0)');
             }
 
@@ -1193,8 +1188,8 @@
                     wrapNode(node);
 
                     const glow = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, node.r * 14);
-                    glow.addColorStop(0, 'rgba(224, 242, 254, 0.95)');
-                    glow.addColorStop(0.35, 'rgba(96, 165, 250, 0.55)');
+                    glow.addColorStop(0, 'rgba(224, 248, 255, 0.95)');
+                    glow.addColorStop(0.35, 'rgba(127, 211, 255, 0.55)');
                     glow.addColorStop(1, 'rgba(5, 5, 7, 0)');
                     ctx.beginPath();
                     ctx.fillStyle = glow;
@@ -1203,7 +1198,7 @@
 
                     ctx.beginPath();
                     ctx.arc(node.x, node.y, node.r, 0, Math.PI * 2);
-                    ctx.fillStyle = 'rgba(96, 165, 250, 0.9)';
+                    ctx.fillStyle = 'rgba(127, 211, 255, 0.9)';
                     ctx.fill();
 
                     for (let j = i + 1; j < nodes.length; j++) {
@@ -1212,8 +1207,8 @@
                         if (dist < 160) {
                             const alpha = 1 - dist / 160;
                             const lineGradient = ctx.createLinearGradient(node.x, node.y, other.x, other.y);
-                            lineGradient.addColorStop(0, `rgba(96, 165, 250, ${alpha * 0.8})`);
-                            lineGradient.addColorStop(1, `rgba(11, 31, 75, ${alpha * 0.55})`);
+                            lineGradient.addColorStop(0, `rgba(127, 211, 255, ${alpha * 0.8})`);
+                            lineGradient.addColorStop(1, `rgba(5, 59, 90, ${alpha * 0.55})`);
                             ctx.strokeStyle = lineGradient;
                             ctx.lineWidth = 0.6 + alpha * 1.1;
                             ctx.beginPath();
@@ -1226,7 +1221,7 @@
                     if (Math.random() < 0.002) {
                         const sparkle = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, node.r * 18);
                         sparkle.addColorStop(0, 'rgba(255, 255, 255, 0.95)');
-                        sparkle.addColorStop(0.4, 'rgba(96, 165, 250, 0.5)');
+                        sparkle.addColorStop(0.4, 'rgba(127, 211, 255, 0.5)');
                         sparkle.addColorStop(1, 'rgba(5, 5, 7, 0)');
                         ctx.fillStyle = sparkle;
                         ctx.beginPath();

--- a/BlackridgePortfolio/privacy.html
+++ b/BlackridgePortfolio/privacy.html
@@ -32,8 +32,8 @@
                         'rich-black': '#050507',
                         'onyx': '#111118',
                         'divider': 'rgba(255,255,255,0.08)',
-                        'gilded': '#D4AF37',
-                        'gilded-soft': '#F5E6B3',
+                        'gilded': '#0A8ED4',
+                        'gilded-soft': '#AEEFFF',
                         'soft-gray': '#9CA3AF',
                         'cool-gray': '#6B7280'
                     }
@@ -45,8 +45,8 @@
     <style>
         :root {
             --crestgate-black: #050507;
-            --crestgate-gold-base: #d4af37;
-            --crestgate-gold-highlight: #f7e7a4;
+            --crestgate-accent-base: #0a8ed4;
+            --crestgate-accent-highlight: #7fd3ff;
         }
 
         html {
@@ -73,8 +73,8 @@
             position: absolute;
             inset: 0;
             pointer-events: none;
-            background: radial-gradient(circle at 12% 10%, rgba(217, 185, 87, 0.08), transparent 42%),
-                        radial-gradient(circle at 88% 14%, rgba(255, 232, 163, 0.06), transparent 48%);
+            background: radial-gradient(circle at 12% 10%, rgba(10, 142, 212, 0.1), transparent 42%),
+                        radial-gradient(circle at 88% 14%, rgba(127, 211, 255, 0.08), transparent 48%);
             opacity: 0.5;
         }
 
@@ -85,13 +85,13 @@
 
         header.site-header {
             background: linear-gradient(135deg, rgba(5, 5, 7, 0.95), rgba(10, 10, 14, 0.78));
-            border-bottom: 1px solid rgba(255, 232, 163, 0.18);
+            border-bottom: 1px solid rgba(127, 211, 255, 0.18);
             box-shadow: 0 25px 65px rgba(0, 0, 0, 0.65);
         }
 
         footer.site-footer {
             background: linear-gradient(160deg, rgba(5, 5, 7, 0.95), rgba(14, 12, 8, 0.78));
-            border-top: 1px solid rgba(255, 232, 163, 0.18);
+            border-top: 1px solid rgba(127, 211, 255, 0.18);
             box-shadow: 0 -20px 65px rgba(0, 0, 0, 0.6);
         }
     </style>
@@ -103,13 +103,11 @@
         <nav class="container mx-auto max-w-6xl px-4 py-4">
             <div class="flex items-center justify-between">
                 <div class="flex items-center space-x-3">
-                    <div class="h-11 w-11 rounded-full border border-gilded/60 bg-gradient-to-br from-gilded/20 via-gilded/5 to-transparent flex items-center justify-center">
-                        <span class="text-gilded text-xl font-semibold">B</span>
-                    </div>
                     <div>
                         <span class="block text-sm tracking-[0.4em] uppercase text-gilded">Blackwellen</span>
                         <span class="block text-lg font-semibold text-white">Ltd</span>
                     </div>
+                    <img src="https://i.ibb.co/tTyXFvBL/craiyon-013431-image.png" alt="Blackwellen Ltd logo" class="h-[7.5rem] w-auto object-contain">
                 </div>
                 <a href="index.html" class="text-soft-gray text-sm font-medium hover:text-gilded transition-colors">Back to Website</a>
             </div>
@@ -212,22 +210,17 @@
 
         document.addEventListener('DOMContentLoaded', () => {
             const palette = {
-                base: getComputedStyle(document.documentElement).getPropertyValue('--crestgate-gold-base') || '#d4af37',
-                highlight: getComputedStyle(document.documentElement).getPropertyValue('--crestgate-gold-highlight') || '#f7e7a4'
+                base: getComputedStyle(document.documentElement).getPropertyValue('--crestgate-accent-base') || '#0a8ed4',
+                highlight: getComputedStyle(document.documentElement).getPropertyValue('--crestgate-accent-highlight') || '#7fd3ff'
             };
 
             document.querySelectorAll('.text-gilded').forEach(el => {
-                el.style.textShadow = '0 0 18px rgba(247, 231, 164, 0.45)';
+                el.style.textShadow = '0 0 18px rgba(163, 230, 255, 0.45)';
             });
-
-            const badge = document.querySelector('header .h-11');
-            if (badge) {
-                badge.style.boxShadow = '0 18px 40px rgba(217, 185, 87, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.3)';
-            }
 
             document.querySelectorAll('main a').forEach(link => {
                 link.addEventListener('mouseenter', () => {
-                    link.style.color = palette.highlight.trim() || '#f7e7a4';
+                    link.style.color = palette.highlight.trim() || '#7fd3ff';
                 });
                 link.addEventListener('mouseleave', () => {
                     link.style.color = '';


### PR DESCRIPTION
## Summary
- update the primary and supporting accent palette across the landing page to match the turquoise tones of the provided logo, including gradients, glows, and scripted effects
- swap the privacy policy header badge for the supplied logo and align its colors with the refreshed brand scheme so there are no leftover placeholder marks

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4627075808320a32178633f81f66a